### PR TITLE
Fix page nil error

### DIFF
--- a/jekyll-modular.gemspec
+++ b/jekyll-modular.gemspec
@@ -7,5 +7,5 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.name          = "jekyll-modular"
   spec.summary       = %q{A modular approach to jekyll content}
-  spec.version       = "0.0.4"
+  spec.version       = "0.0.5"
 end

--- a/lib/jekyll/modular-content.rb
+++ b/lib/jekyll/modular-content.rb
@@ -35,7 +35,7 @@ module Jekyll
         modules_dir = File.join(site.source, site.config['modules'])
       end
 
-      return unless page.data['modules']
+      return unless page && page.data && page.data['modules']
 
       html = ''
       page.data['modules'].each do |mod_name|


### PR DESCRIPTION
**Summary:**
I'm not quite sure why this fixes it, but in some instances, when we don't have `page.modules` declared, jekyll blows up. This fixes the issue

**Test Plan:**
Tested w/ an aje-microsites beta